### PR TITLE
adding a typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -1,0 +1,13 @@
+[package]
+# mandatory fields
+name = "evan" 
+version = "0.1.0"
+entrypoint = "evan.typ"
+authors = ["ilya-grigoriev <https://github.com/ilya-grigoriev>"]
+license = "GPL-3.0-only"
+description = "A template for creating presentations in the style of the title card from Evangelion."
+
+# optional fields
+repository = "https://github.com/ilya-grigoriev/evan"
+categories = ["presentation"]
+exclude = ["examples/"]


### PR DESCRIPTION
Hi again,

I just quickly threw a minimal typst.toml together, so that the package can:
    - be installed and used as a package locally, following [this convention](https://github.com/typst/packages?tab=readme-ov-file#local-packages).
    - also makes it possible to submit it upstream to the typst universe package-repo (if you'd want to do that).
    
I've tested and used it myself locally as a part of a local package repo already with no issues. 